### PR TITLE
Handle spaces in STYLE function

### DIFF
--- a/prompt_control/node_clip.py
+++ b/prompt_control/node_clip.py
@@ -189,6 +189,8 @@ def get_style(text, default_style="comfy", default_normalization="none"):
     if not styles:
         return default_style, default_normalization, text
     style, normalization = styles[0]
+    style = style.strip()
+    normalization = normalization.strip()
     if style not in AVAILABLE_STYLES:
         log.warning("Unrecognized prompt style: %s. Using %s", style, default_style)
         style = default_style


### PR DESCRIPTION
## Before

|Style text |Works?|
|-----|------|
|`STYLE(A1111,length+mean)`|✅|
|`STYLE(A1111, length+mean)`|❌|
|`STYLE(A1111 ,length+mean)`|❌|

### Example error
```
[WARNING] PromptControl: Unrecognized prompt style: A1111 . Using comfy
[WARNING] PromptControl: Unrecognized prompt normalization:  length+mean. Using none
[WARNING] PromptControl: Unrecognized prompt style: A1111 . Using comfy
[WARNING] PromptControl: Unrecognized prompt normalization:  length+mean. Using none
[WARNING] PromptControl: Unrecognized prompt style: A1111 . Using comfy
[WARNING] PromptControl: Unrecognized prompt normalization:  length+mean. Using none
[WARNING] PromptControl: Unrecognized prompt style: A1111 . Using comfy
[WARNING] PromptControl: Unrecognized prompt normalization:  length+mean. Using none
```

### Repro Workflow
[style_test.json](https://github.com/asagi4/comfyui-prompt-control/files/15192396/style_test.json)

