### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,14 @@ name = "comfyui-prompt-control"
 description = "Nodes for convenient prompt editing. The aim is to make basic generations in ComfyUI completely prompt-controllable."
 version = "1.0.0"
 license = "LICENSE"
-dependencies = ["# some lark versions older than 1.1.9 apparently have a bug that breaks things, see https://github.com/asagi4/comfyui-prompt-control/issues/35", "lark >= 1.1.9"]
+# # some lark versions older than 1.1.9 apparently have a bug that breaks things, see https://github.com/asagi4/comfyui-prompt-control/issues/35
+dependencies = ["lark >= 1.1.9"]
 
 [project.urls]
 Repository = "https://github.com/asagi4/comfyui-prompt-control"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
-DisplayName = "comfyui-prompt-control"
+PublisherId = "asagi4"
+DisplayName = "ComfyUI Prompt Control"
 Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-prompt-control"
+description = "Nodes for convenient prompt editing. The aim is to make basic generations in ComfyUI completely prompt-controllable."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["# some lark versions older than 1.1.9 apparently have a bug that breaks things, see https://github.com/asagi4/comfyui-prompt-control/issues/35", "lark >= 1.1.9"]
+
+[project.urls]
+Repository = "https://github.com/asagi4/comfyui-prompt-control"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "comfyui-prompt-control"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!