### PR TITLE
Partially resolve #115

### DIFF
--- a/prompt_control/adv_encode.py
+++ b/prompt_control/adv_encode.py
@@ -117,7 +117,7 @@ def down_weight(tokens, weights, word_ids, base_emb, pooled_base, max_length, en
     w_mix = torch.tensor(w_mix, dtype=embs.dtype, device=embs.device).reshape((-1, 1, 1))
 
     weighted_emb = (w_mix * embs).sum(axis=0, keepdim=True)
-    if pooled and max_length:
+    if pooled is not None and max_length:
         pooled = weighted_emb[0, max_length - 1 : max_length, :]
     return weighted_emb, masked_current, pooled
 


### PR DESCRIPTION
This PR fixes `Boolean value of Tensor with more than one value is ambiguous` error.

Also, shouldn't this check be something like `if pooled is None` instead of `if pooled is not None`?