### PR TITLE
fix: restore [other, couple] attn patch order after Comfy core 493b81e (#135)

### DIFF
--- a/prompt_control/attention_couple_ppm.py
+++ b/prompt_control/attention_couple_ppm.py
@@ -128,7 +128,27 @@ class AttentionCoupleHook(TransformerOptionsHook):
             else:
                 self.kv["k"] = self.kv["v"] = self.conds[1:]
 
-        return super().on_apply_hooks(model, transformer_options)
+        result = super().on_apply_hooks(model, transformer_options)
+
+        # AttentionCouple's masked attention math must run AFTER any other
+        # attn2_patch / attn2_output_patch entries (e.g. NegPip from
+        # ComfyUI-ppm) so it operates on already-sliced k/v tensors.
+        # Pre Comfy-Org/ComfyUI@493b81e, merge_nested_dicts naturally produced
+        # [<existing>, couple]. After the arg-swap in 493b81e it produces
+        # [couple, <existing>], breaking the order. Restore the invariant
+        # explicitly here so the hook is robust to merge-order changes in core.
+        couple_patches = self.transformers_dict.get("patches", {})
+        patches = transformer_options.get("patches", {})
+        for patch_name in ("attn2_patch", "attn2_output_patch"):
+            patch_list = patches.get(patch_name)
+            if not patch_list:
+                continue
+            for proxy in couple_patches.get(patch_name, []):
+                if proxy in patch_list and patch_list[-1] is not proxy:
+                    patch_list.remove(proxy)
+                    patch_list.append(proxy)
+
+        return result
 
     def clone(self):
         c: AttentionCoupleHook = super().clone()


### PR DESCRIPTION
## Bug

Refs #135. AttentionCouple regions stop being applied when `CLIP NegPip` from `ComfyUI-ppm` is active, after Comfy-Org/ComfyUI@493b81e (\"Fix order of inputs nested merge_nested_dicts\").

## Root cause (per the issue thread, verified against the diff)

`AttentionCoupleHook.transformers_dict` registers two patches:

\`\`\`py
self.transformers_dict = {
    \"patches\": {
        \"attn2_output_patch\": [Proxy(self.attn2_output_patch)],
        \"attn2_patch\": [Proxy(self.attn2_patch)],
    }
}
\`\`\`

Both `attn2_patch` and `attn2_output_patch` are list-valued — multiple extensions can register patches into the same key, and they run in list order. Couple's masked-attention math expects to run **after** any pre-existing patches (e.g. NegPip's), so it operates on already-negpip-sliced k/v tensors.

Before 493b81e, Comfy core's `merge_nested_dicts` extended new lists onto existing ones, so when AttentionCouple registered after NegPip, `attn2_patch` ended up as `[negpip_patch, couple_patch]` and ran in that order by happy coincidence.

After 493b81e (`merge_nested_dicts(curr_value, value)` → `merge_nested_dicts(value, curr_value)`), the order is reversed: `[couple_patch, negpip_patch]`. Couple's per-region attention happens first on un-sliced V, and NegPip's downstream V swap then washes out the per-region weighting.

## Fix

Approach (a) from my comment on #135 — the minimal change. Keep `transformers_dict` registration as-is, then in `on_apply_hooks`, after `super()` does its merge, identity-check our cached `Proxy` instances in the resulting list and move them to the end if anything sits behind them.

\`\`\`py
result = super().on_apply_hooks(model, transformer_options)

couple_patches = self.transformers_dict.get(\"patches\", {})
patches = transformer_options.get(\"patches\", {})
for patch_name in (\"attn2_patch\", \"attn2_output_patch\"):
    patch_list = patches.get(patch_name)
    if not patch_list:
        continue
    for proxy in couple_patches.get(patch_name, []):
        if proxy in patch_list and patch_list[-1] is not proxy:
            patch_list.remove(proxy)
            patch_list.append(proxy)

return result
\`\`\`

Properties:

- **Idempotent** — no-op if our patches are already last in the list. Safe to run on every hook application.
- **Identity-checked** — `proxy in patch_list` and `patch_list[-1] is not proxy` use the cached `Proxy` instances from `transformers_dict`, so we only ever touch our own entries. Other extensions' patches are untouched.
- **Robust to future merges** — works regardless of which way Comfy core decides to merge in any future revision; we no longer depend on the dict-merge order being a particular way.
- **No changes to** `__init__`, `clone()`, or the `Proxy` registration mechanism. Other call sites remain unaffected.

I considered approach (b) (skip `transformers_dict` registration entirely, append manually in `on_apply_hooks`) but it changes more surface area (clone semantics, what happens when `transformers_dict[\"patches\"]` is empty inside `TransformerOptionsHook.on_apply_hooks`, etc.) and isn't strictly necessary for this fix. Happy to switch to (b) if you'd prefer the more structural change.

## Verification status

**Marked draft because I have not run a NegPip+COUPLE workflow end-to-end.** I don't have one set up locally, and the symptom is subtle (regions get washed out — needs a visual diff to confirm). Reasoning chain:

1. Diagnosis matches @higana-yogana's investigation in #135 (they verified manually that reverting 493b81e restored correct behavior).
2. The fix forces the patch list back to the order that worked pre-493b81e.
3. Strict reduction in surprising behavior — can't make a working setup worse.

But I'd much rather not ping you with broken code. **@higana-yogana** — if you still have the failing workflow handy, this branch should restore region weighting; happy to keep iterating if it doesn't.

@asagi4 — flip out of draft + merge if/when you (or higana-yogana) confirm. If you'd rather take this and rewrite, totally fine — leave the analysis as-is and I'll close.

Refs #135.